### PR TITLE
Fix the bug where balancing the crafting grid would combine items of the same type but differing NBT data

### DIFF
--- a/shared/src/main/java/net/blay09/mods/craftingtweaks/api/impl/DefaultGridBalanceHandler.java
+++ b/shared/src/main/java/net/blay09/mods/craftingtweaks/api/impl/DefaultGridBalanceHandler.java
@@ -34,7 +34,7 @@ public class DefaultGridBalanceHandler implements GridBalanceHandler<AbstractCon
                 ResourceLocation registryName = Registry.ITEM.getKey(itemStack.getItem());
                 String key = Objects.toString(registryName);
                 if (itemStack.getTag() != null) {
-                    key = key + itemStack.getTag().toString();
+                    key = key + "@" + itemStack.getTag().toString();
                 }
                 itemMap.put(key, itemStack);
                 itemCount.add(key, itemStack.getCount());

--- a/shared/src/main/java/net/blay09/mods/craftingtweaks/api/impl/DefaultGridBalanceHandler.java
+++ b/shared/src/main/java/net/blay09/mods/craftingtweaks/api/impl/DefaultGridBalanceHandler.java
@@ -33,6 +33,9 @@ public class DefaultGridBalanceHandler implements GridBalanceHandler<AbstractCon
             if (!itemStack.isEmpty() && itemStack.getMaxStackSize() > 1) {
                 ResourceLocation registryName = Registry.ITEM.getKey(itemStack.getItem());
                 String key = Objects.toString(registryName);
+                if (itemStack.getTag() != null) {
+                    key = key + itemStack.getTag().toString();
+                }
                 itemMap.put(key, itemStack);
                 itemCount.add(key, itemStack.getCount());
             }


### PR DESCRIPTION
This is to fix the bug described in #156.

The issue is in the following blurb of code from [DefaultGridBalanceHandler.java](https://github.com/nathanrsfba/CraftingTweaks/blob/681d4f96e4f7b6b0b8af31d9963f75e38723409e/shared/src/main/java/net/blay09/mods/craftingtweaks/api/impl/DefaultGridBalanceHandler.java#L34):

```
ResourceLocation registryName = Registry.ITEM.getKey(itemStack.getItem());
String key = Objects.toString(registryName);
itemMap.put(key, itemStack);
itemCount.add(key, itemStack.getCount());
```

The problem is that the code is creating a map and a set to keep track of each different 'type' of item in the grid. However, the key for both is only based on the item's registry name, and not the NBT data. Thus, objects of the same type but different NBT values will 'look identical' to the balancing code.

The fix is to append the NBT data to the key in string form:

```
if (itemStack.getTag() != null) {
    key = key + "@" + itemStack.getTag().toString();
}
```

This way, items with different NBT values will now be considered different from each other, and from items with no NBT data.

Fixes for previous versions are basically the same, though the code for each is slightly different.